### PR TITLE
Added ADS reserved index groups and implemented access with index gro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,46 @@ client = ads.connect(options, function() {
 })
 ```
 
+### Event-Driven Detection of Changes to the Symbol Table
+
+If the symbol table changes because, for instance, a new PLC program is written into the controller, the handles must be ascertained once again. The example below illustrates how changes to the symbol table can be detected.
+
+```javascript
+
+var start = true;
+
+var myHandle = {
+    indexGroup: ads.ADSIGRP.SYM_VERSION,
+    indexOffset: 0,
+    bytelength: ads.BYTE,  
+}
+
+var client = ads.connect(options, function() {
+    start = true;
+    this.notify(myHandle);
+})
+
+client.on('notification', function(handle){
+    if (start) {
+      console.log('symbol table version '+handle.value)
+    } else {
+      console.log('symbol table changed '+handle.value)
+    }
+    
+    start = false;
+})
+
+process.on('SIGINT', function() {
+    client.end(function() {
+        process.exit()
+    })
+})
+
+client.on('error', function(error) {
+    console.log(error)
+})
+```
+
 License (MIT)
 -------------
 Copyright (c) 2012 Inando

--- a/lib/ads.js
+++ b/lib/ads.js
@@ -268,7 +268,7 @@ var multiRead = function (commandOptions, cb) {
   })
 
   var options = {
-    indexGroup: 0xF080,
+    indexGroup: ADSIGRP.SUMUP_READ,
     indexOffset: commandOptions.length,
     writeBuffer: buf,
     readLength: readLength + commandOptions.length * 4,
@@ -335,7 +335,7 @@ var read = function (handle, cb) {
   getHandle.call(ads, handle, function (err, handle) {
     if (!err) {
       var commandOptions = {
-        indexGroup: handle.indexGroup || 0x0000F005,
+        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         symname: handle.symnane
@@ -361,7 +361,7 @@ var write = function (handle, cb) {
     if (!err) {
       getBytesFromHandle(handle)
       var commandOptions = {
-        indexGroup: handle.indexGroup || 0x0000F005,
+        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         bytes: handle.bytes,
@@ -386,7 +386,7 @@ var notify = function (handle, cb) {
   getHandle.call(ads, handle, function (err, handle) {
     if (!err) {
       var commandOptions = {
-        indexGroup: 0x0000F005,
+        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         transmissionMode: handle.transmissionMode,
@@ -412,13 +412,13 @@ var notify = function (handle, cb) {
 var getSymbols = function (cb) {
   var ads = this
   var cmdLength = {
-    indexGroup: 0x0000F00F,
+    indexGroup: ADSIGRP.SYM_UPLOADINFO2,
     indexOffset: 0x00000000,
     bytelength: 0x30
   }
 
   var cmdSymbols = {
-    indexGroup: 0x0000F00B,
+    indexGroup: ADSIGRP.SYM_UPLOAD,
     indexOffset: 0x00000000
   }
 
@@ -497,29 +497,34 @@ var getSymbols = function (cb) {
 var getHandle = function (handle, cb) {
   var ads = this
   handle = parseHandle(handle)
-  var buf = stringToBuffer(handle.symname)
+  if (typeof handle.symname === 'undefined') {
+    handle.symname = handle.indexOffset
+    cb.call(ads, null, handle)
+  } else {
+    var buf = stringToBuffer(handle.symname)
 
-  if (typeof handle.symhandle === 'undefined') {
-    var commandOptions = {
-      indexGroup: 0x0000F003,
-      indexOffset: 0x00000000,
-      writeBuffer: buf,
-      readLength: 4,
-      symname: handle.symname
-    }
-
-    writeReadCommand.call(ads, commandOptions, function (err, result) {
-      if (err) {
-        cb.call(ads, err)
-      } else {
-        if (result.length > 0) {
-          ads.symHandlesToRelease.push(result)
-          handle.symhandle = result.readUInt32LE(0)
-          cb.call(ads, null, handle)
-        }
+    if (typeof handle.symhandle === 'undefined') {
+      var commandOptions = {
+        indexGroup: ADSIGRP.SYM_HNDBYNAME,
+        indexOffset: 0x00000000,
+        writeBuffer: buf,
+        readLength: 4,
+        symname: handle.symname
       }
-    })
-  } else cb.call(ads, null, handle)
+
+      writeReadCommand.call(ads, commandOptions, function (err, result) {
+        if (err) {
+          cb.call(ads, err)
+        } else {
+          if (result.length > 0) {
+            ads.symHandlesToRelease.push(result)
+            handle.symhandle = result.readUInt32LE(0)
+            cb.call(ads, null, handle)
+          }
+        }
+      })
+    } else cb.call(ads, null, handle)
+  }
 }
 
 var releaseSymHandles = function (cb) {
@@ -535,7 +540,7 @@ var releaseSymHandles = function (cb) {
 var releaseSymHandle = function (symhandle, cb) {
   var ads = this
   var commandOptions = {
-    indexGroup: 0x0000F006,
+    indexGroup: ADSIGRP.SYM_RELEASEHND,
     indexOffset: 0x00000000,
     bytelength: symhandle.length,
     bytes: symhandle
@@ -985,8 +990,9 @@ var integrateResultInHandle = function (handle, result) {
 }
 
 var parseHandle = function (handle) {
-  if (typeof handle.symname === 'undefined') {
-    throw new Error("The handle doesn't have a symname property!")
+  if (typeof handle.symname === 'undefined' && 
+      (typeof handle.indexGroup === 'undefined' || typeof handle.indexOffset === 'undefined') ) {
+    throw new Error("The handle doesn't have a symname or an indexGroup and indexOffset property!")
   }
 
   if (typeof handle.propname !== 'undefined') {
@@ -1329,4 +1335,61 @@ exports.string = function (length) {
 exports.NOTIFY = {
   CYCLIC: 3,
   ONCHANGE: 4
+}
+
+// ADS reserved index groups
+var ADSIGRP = {
+  SYMTAB:             0xF000,
+  SYMNAME:            0xF001,
+  SYMVAL:             0xF002,
+  SYM_HNDBYNAME:      0xF003,
+  SYM_VALBYNAME:      0xF004,
+  SYM_VALBYHND:       0xF005,
+  SYM_RELEASEHND:     0xF006,
+  SYM_INFOBYNAME:     0xF007,
+  SYM_VERSION:        0xF008,
+  SYM_INFOBYNAMEEX:   0xF009,
+  SYM_DOWNLOAD:       0xF00A,
+  SYM_UPLOAD:         0xF00B,
+  SYM_UPLOADINFO:     0xF00C,
+  SYM_DOWNLOAD2:      0xF00D,
+  SYM_DT_UPLOAD:      0xF00E,
+  SYM_UPLOADINFO2:    0xF00F,
+  SYMNOTE:            0xF010,    // notification of named handle
+  SUMUP_READ:         0xF080,    // AdsRW  IOffs list size or 0 (=0 -> list size == WLength/3*sizeof(ULONG))
+                    // W: {list of IGrp, IOffs, Length}
+                    // if IOffs != 0 then R: {list of results} and {list of data}
+                    // if IOffs == 0 then R: only data (sum result)
+  SUMUP_WRITE:        0xF081,    // AdsRW  IOffs list size
+                    // W: {list of IGrp, IOffs, Length} followed by {list of data}
+                    // R: list of results
+  SUMUP_READWRITE:    0xF082,    // AdsRW  IOffs list size
+                    // W: {list of IGrp, IOffs, RLength, WLength} followed by {list of data}
+                    // R: {list of results, RLength} followed by {list of data}
+  SUMUP_READEX:       0xF083,    // AdsRW  IOffs list size
+                    // W: {list of IGrp, IOffs, Length}
+  SUMUP_READEX2:      0xF084,    // AdsRW  IOffs list size
+                    // W: {list of IGrp, IOffs, Length}
+                    // R: {list of results, Length} followed by {list of data (returned lengths)}
+  SUMUP_ADDDEVNOTE:   0xF085,    // AdsRW  IOffs list size
+                    // W: {list of IGrp, IOffs, Attrib}
+                    // R: {list of results, handles}
+  SUMUP_DELDEVNOTE:   0xF086,    // AdsRW  IOffs list size
+                    // W: {list of handles}
+                    // R: {list of results, Length} followed by {list of data}
+  IOIMAGE_RWIB:       0xF020,    // read/write input byte(s)
+  IOIMAGE_RWIX:       0xF021,    // read/write input bit
+  IOIMAGE_RISIZE:     0xF025,    // read input size (in byte)
+  IOIMAGE_RWOB:       0xF030,    // read/write output byte(s)
+  IOIMAGE_RWOX:       0xF031,    // read/write output bit
+  IOIMAGE_CLEARI:     0xF040,    // write inputs to null
+  IOIMAGE_CLEARO:     0xF050,    // write outputs to null
+  IOIMAGE_RWIOB:      0xF060,    // read input and write output byte(s)
+  DEVICE_DATA:        0xF100,    // state, name, etc...
+}
+exports.ADSIGRP = ADSIGRP;
+
+exports.ADSIOFFS_DEVDATA = {
+  ADSSTATE:           0x0000, // ads state of device
+  DEVSTATE:           0x0002  // device state
 }

--- a/lib/ads.js
+++ b/lib/ads.js
@@ -335,7 +335,7 @@ var read = function (handle, cb) {
   getHandle.call(ads, handle, function (err, handle) {
     if (!err) {
       var commandOptions = {
-        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
+        indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         symname: handle.symnane
@@ -361,7 +361,7 @@ var write = function (handle, cb) {
     if (!err) {
       getBytesFromHandle(handle)
       var commandOptions = {
-        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
+        indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         bytes: handle.bytes,
@@ -386,7 +386,7 @@ var notify = function (handle, cb) {
   getHandle.call(ads, handle, function (err, handle) {
     if (!err) {
       var commandOptions = {
-        indexGroup: handle.indexGroup || ADSIGRP.SYM_VALBYHND,
+        indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
         indexOffset: handle.symhandle,
         bytelength: handle.totalByteLength,
         transmissionMode: handle.transmissionMode,
@@ -505,7 +505,7 @@ var getHandle = function (handle, cb) {
 
     if (typeof handle.symhandle === 'undefined') {
       var commandOptions = {
-        indexGroup: ADSIGRP.SYM_HNDBYNAME,
+        indexGroup: ADSIGRP.GET_SYMHANDLE_BYNAME,
         indexOffset: 0x00000000,
         writeBuffer: buf,
         readLength: 4,
@@ -540,7 +540,7 @@ var releaseSymHandles = function (cb) {
 var releaseSymHandle = function (symhandle, cb) {
   var ads = this
   var commandOptions = {
-    indexGroup: ADSIGRP.SYM_RELEASEHND,
+    indexGroup: ADSIGRP.RELEASE_SYMHANDLE,
     indexOffset: 0x00000000,
     bytelength: symhandle.length,
     bytes: symhandle
@@ -1339,57 +1339,57 @@ exports.NOTIFY = {
 
 // ADS reserved index groups
 var ADSIGRP = {
-  SYMTAB:             0xF000,
-  SYMNAME:            0xF001,
-  SYMVAL:             0xF002,
-  SYM_HNDBYNAME:      0xF003,
-  SYM_VALBYNAME:      0xF004,
-  SYM_VALBYHND:       0xF005,
-  SYM_RELEASEHND:     0xF006,
-  SYM_INFOBYNAME:     0xF007,
-  SYM_VERSION:        0xF008,
-  SYM_INFOBYNAMEEX:   0xF009,
-  SYM_DOWNLOAD:       0xF00A,
-  SYM_UPLOAD:         0xF00B,
-  SYM_UPLOADINFO:     0xF00C,
-  SYM_DOWNLOAD2:      0xF00D,
-  SYM_DT_UPLOAD:      0xF00E,
-  SYM_UPLOADINFO2:    0xF00F,
-  SYMNOTE:            0xF010,    // notification of named handle
-  SUMUP_READ:         0xF080,    // AdsRW  IOffs list size or 0 (=0 -> list size == WLength/3*sizeof(ULONG))
-                    // W: {list of IGrp, IOffs, Length}
-                    // if IOffs != 0 then R: {list of results} and {list of data}
-                    // if IOffs == 0 then R: only data (sum result)
-  SUMUP_WRITE:        0xF081,    // AdsRW  IOffs list size
-                    // W: {list of IGrp, IOffs, Length} followed by {list of data}
-                    // R: list of results
-  SUMUP_READWRITE:    0xF082,    // AdsRW  IOffs list size
-                    // W: {list of IGrp, IOffs, RLength, WLength} followed by {list of data}
-                    // R: {list of results, RLength} followed by {list of data}
-  SUMUP_READEX:       0xF083,    // AdsRW  IOffs list size
-                    // W: {list of IGrp, IOffs, Length}
-  SUMUP_READEX2:      0xF084,    // AdsRW  IOffs list size
-                    // W: {list of IGrp, IOffs, Length}
-                    // R: {list of results, Length} followed by {list of data (returned lengths)}
-  SUMUP_ADDDEVNOTE:   0xF085,    // AdsRW  IOffs list size
-                    // W: {list of IGrp, IOffs, Attrib}
-                    // R: {list of results, handles}
-  SUMUP_DELDEVNOTE:   0xF086,    // AdsRW  IOffs list size
-                    // W: {list of handles}
-                    // R: {list of results, Length} followed by {list of data}
-  IOIMAGE_RWIB:       0xF020,    // read/write input byte(s)
-  IOIMAGE_RWIX:       0xF021,    // read/write input bit
-  IOIMAGE_RISIZE:     0xF025,    // read input size (in byte)
-  IOIMAGE_RWOB:       0xF030,    // read/write output byte(s)
-  IOIMAGE_RWOX:       0xF031,    // read/write output bit
-  IOIMAGE_CLEARI:     0xF040,    // write inputs to null
-  IOIMAGE_CLEARO:     0xF050,    // write outputs to null
-  IOIMAGE_RWIOB:      0xF060,    // read input and write output byte(s)
-  DEVICE_DATA:        0xF100,    // state, name, etc...
+  SYMTAB:               0xF000,
+  SYMNAME:              0xF001,
+  SYMVAL:               0xF002,
+  GET_SYMHANDLE_BYNAME: 0xF003, // {TcAdsDef.h: ADSIGRP_SYM_HNDBYNAME}
+  READ_SYMVAL_BYNAME:   0xF004, // {TcAdsDef.h: ADSIGRP_SYM_VALBYNAME}
+  RW_SYMVAL_BYHANDLE:   0xF005, // {TcAdsDef.h: ADSIGRP_SYM_VALBYHND}
+  RELEASE_SYMHANDLE:    0xF006, // {TcAdsDef.h: ADSIGRP_SYM_RELEASEHND}
+  SYM_INFOBYNAME:       0xF007,
+  SYM_VERSION:          0xF008,
+  SYM_INFOBYNAMEEX:     0xF009,
+  SYM_DOWNLOAD:         0xF00A,
+  SYM_UPLOAD:           0xF00B,
+  SYM_UPLOADINFO:       0xF00C,
+  SYM_DOWNLOAD2:        0xF00D,
+  SYM_DT_UPLOAD:        0xF00E,
+  SYM_UPLOADINFO2:      0xF00F,
+  SYMNOTE:              0xF010,    // notification of named handle
+  SUMUP_READ:           0xF080,    // AdsRW  IOffs list size or 0 (=0 -> list size == WLength/3*sizeof(ULONG))
+                      // W: {list of IGrp, IOffs, Length}
+                      // if IOffs != 0 then R: {list of results} and {list of data}
+                      // if IOffs == 0 then R: only data (sum result)
+  SUMUP_WRITE:          0xF081,    // AdsRW  IOffs list size
+                      // W: {list of IGrp, IOffs, Length} followed by {list of data}
+                      // R: list of results
+  SUMUP_READWRITE:      0xF082,    // AdsRW  IOffs list size
+                      // W: {list of IGrp, IOffs, RLength, WLength} followed by {list of data}
+                      // R: {list of results, RLength} followed by {list of data}
+  SUMUP_READEX:         0xF083,    // AdsRW  IOffs list size
+                      // W: {list of IGrp, IOffs, Length}
+  SUMUP_READEX2:        0xF084,    // AdsRW  IOffs list size
+                      // W: {list of IGrp, IOffs, Length}
+                      // R: {list of results, Length} followed by {list of data (returned lengths)}
+  SUMUP_ADDDEVNOTE:     0xF085,    // AdsRW  IOffs list size
+                      // W: {list of IGrp, IOffs, Attrib}
+                      // R: {list of results, handles}
+  SUMUP_DELDEVNOTE:     0xF086,    // AdsRW  IOffs list size
+                      // W: {list of handles}
+                      // R: {list of results, Length} followed by {list of data}
+  IOIMAGE_RWIB:         0xF020,    // read/write input byte(s)
+  IOIMAGE_RWIX:         0xF021,    // read/write input bit
+  IOIMAGE_RISIZE:       0xF025,    // read input size (in byte)
+  IOIMAGE_RWOB:         0xF030,    // read/write output byte(s)
+  IOIMAGE_RWOX:         0xF031,    // read/write output bit
+  IOIMAGE_CLEARI:       0xF040,    // write inputs to null
+  IOIMAGE_CLEARO:       0xF050,    // write outputs to null
+  IOIMAGE_RWIOB:        0xF060,    // read input and write output byte(s)
+  DEVICE_DATA:          0xF100,    // state, name, etc...
 }
 exports.ADSIGRP = ADSIGRP;
 
 exports.ADSIOFFS_DEVDATA = {
-  ADSSTATE:           0x0000, // ads state of device
-  DEVSTATE:           0x0002  // device state
+  ADSSTATE:             0x0000, // ads state of device
+  DEVSTATE:             0x0002  // device state
 }


### PR DESCRIPTION
Added ADS reserved index groups and implemented access with index group and index offset.

One reason was the Event-Driven Detection of Changes to the Symbol Table.
If the symbol table changes because, for instance, a new PLC program is written into the controller, the handles must be ascertained once again. The example below illustrates how changes to the symbol table can be detected.

```javascript

var start = true;

var myHandle = {
    indexGroup: ads.ADSIGRP.SYM_VERSION,
    indexOffset: 0,
    bytelength: ads.BYTE,  
}

var client = ads.connect(options, function() {
    start = true;
    this.notify(myHandle);
})

client.on('notification', function(handle){
    if (start) {
      console.log('symbol table version '+handle.value)
    } else {
      console.log('symbol table changed '+handle.value)
    }
    
    start = false;
})

process.on('SIGINT', function() {
    client.end(function() {
        process.exit()
    })
})

client.on('error', function(error) {
    console.log(error)
})
```



