### PR TITLE
exception when not connected:

### DIFF
--- a/lib/ads.js
+++ b/lib/ads.js
@@ -412,11 +412,13 @@ var notify = function (handle, cb) {
       }
 
       addNotificationCommand.call(ads, commandOptions, function (err, notiHandle) {
-        if (ads.options.verbose > 0) {
-          debug('Add notiHandle ' + notiHandle)
-        }
+        if (!err) {
+          if (ads.options.verbose > 0) {
+            debug('Add notiHandle ' + notiHandle)
+          }
 
-        this.notifications[notiHandle] = handle
+          this.notifications[notiHandle] = handle
+        }
         if (typeof cb !== 'undefined') {
           cb.call(ads.adsClient, err)
         }


### PR DESCRIPTION
exception when ads is not connected:
4 Aug 23:29:04 - TypeError: Cannot set property 'undefined' of undefined
    at Object.cb (e:\node\node_modules\node-ads\lib\ads.js:419:40)
    at Object.<anonymous> (e:\node\node_modules\node-ads\lib\ads.js:736:15)
    at ontimeout (timers.js:498:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:290:5)

I think it's better not to access the notiHandle if err is given