### PR TITLE
Fixed getSymbols function, there was a bug according to the length of…

### DIFF
--- a/lib/ads.js
+++ b/lib/ads.js
@@ -568,9 +568,11 @@ var getSymbols = function (cb, raw) {
       readCommand.call(ads, cmdSymbols, function (err, result) {
         var symbols = []
         var pos = 0
+        var initialPos = 0
         if (!err) {
           while (pos < result.length) {
             var symbol = {}
+            initialPos = pos;
             var readLength = result.readUInt32LE(pos)
             symbol.indexGroup = result.readUInt32LE(pos + 4)
             symbol.indexOffset = result.readUInt32LE(pos + 8)
@@ -621,6 +623,8 @@ var getSymbols = function (cb, raw) {
             } else {
               symbols.push(symbol)
             }
+
+            pos = initialPos + readLength;
           }
         }
 


### PR DESCRIPTION
… one symbol (reading next symbol started at wrong position)

I tried it with the official C++ library of Beckhoff and it seems to work (got all my 18 symbols back).
This JS library crashed while copying something into the new buffer. The problem was that the length of the symbol was ignored.

If somebody needs my TwinCat project please let me know.