### PR TITLE
Fixed ADS indexOffset, always returning 0 or false

### DIFF
--- a/lib/ads.js
+++ b/lib/ads.js
@@ -498,7 +498,7 @@ var read = function (handle, cb) {
     if (!err) {
       var commandOptions = {
         indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
-        indexOffset: handle.symhandle,
+        indexOffset: handle.indexOffset || handle.symhandle,
         bytelength: handle.totalByteLength,
         symname: handle.symnane
       }
@@ -520,7 +520,7 @@ var write = function (handle, cb) {
       getBytesFromHandle(handle)
       var commandOptions = {
         indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
-        indexOffset: handle.symhandle,
+        indexOffset: handle.indexOffset || handle.symhandle,
         bytelength: handle.totalByteLength,
         bytes: handle.bytes,
         symname: handle.symname
@@ -541,7 +541,7 @@ var notify = function (handle, cb) {
     if (!err) {
       var commandOptions = {
         indexGroup: handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,
-        indexOffset: handle.symhandle,
+        indexOffset: handle.indexOffset || handle.symhandle,
         bytelength: handle.totalByteLength,
         transmissionMode: handle.transmissionMode,
         maxDelay: handle.maxDelay,

--- a/lib/ads.js
+++ b/lib/ads.js
@@ -316,7 +316,7 @@ var multiRead = function (handles, cb) {
         handles.forEach(function(handle) {
           if (!handle.err){
             buf.writeUInt32LE(handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,index)
-            buf.writeUInt32LE(handle.symhandle,index+4)
+            buf.writeUInt32LE(handle.indexOffset || handle.symhandle,index+4)
             buf.writeUInt32LE(handle.totalByteLength,index+8)
             index+=12
           }
@@ -382,7 +382,7 @@ var multiWrite = function (handles, cb) {
         handles.forEach(function(handle) {
           if (!handle.err){
             buf.writeUInt32LE(handle.indexGroup || ADSIGRP.RW_SYMVAL_BYHANDLE,0)
-            buf.writeUInt32LE(handle.symhandle,4)
+            buf.writeUInt32LE(handle.indexOffset || handle.symhandle,4)
             buf.writeUInt32LE(handle.totalByteLength,8)
             index+=12
             getBytesFromHandle(handle)


### PR DESCRIPTION
Fix for a bug which caused any value read, notify or write always returning 0 or false
The changes aren't breaking.